### PR TITLE
Config loading fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,10 +349,10 @@ _Browser Report_
 Using the report property in `backstop.json` enable or disable browser or server-side-reporting by including/excluding the respective properties. The following settings will run both reports at the same time.
 
 ```json
-"report": ["browser", "CLI"]
+"report": ["browser", "CI"]
 ```
 
-If you choose the CLI-only reporting you can always enter the following command to see the latest test run report in the browser.
+If you choose the CI-only reporting you can always enter the following command to see the latest test run report in the browser.
 
 ```sh
 $ backstop openReport
@@ -363,7 +363,7 @@ $ backstop openReport
 The following config would enable the CI - report (*default: junit format*)
 
 ```json
-"report" : [ "CLI" ,  "CI" ],
+"report" : [ "CI" ],
 ```
 
 The regression test report will be generated in the JUnit format and the report will be placed in the given directory (*default: [backstopjs dir]/test/ci_report/xunit.xml*).

--- a/capture/config.default.json
+++ b/capture/config.default.json
@@ -46,7 +46,7 @@
     "casper_scripts": "backstop_data/casper_scripts"
   },
   "engine": "phantomjs",
-  "report": ["CLI", "browser"],
+  "report": ["browser"],
   "casperFlags": [],
   "debug": false,
   "port": 3001

--- a/cli/index.js
+++ b/cli/index.js
@@ -38,19 +38,7 @@ if (!commandName) {
   process.exit();
 } else {
 
-  var config = {};
-
-  if (argsOptions['configPath']) {
-    try {
-      config = require(path.join(process.cwd(), argsOptions['configPath']));
-    } catch (e) {
-      console.error("Error " + e);
-      process.exit(1);
-    }
-  }
-
-  config = makeConfig(config, argsOptions);
-
+  var config = makeConfig(argsOptions);
   var exitCode = 0;
   executeCommand(commandName, config).catch(function() {
     exitCode = 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstopjs",
-  "version": "1.3.6",
+  "version": "2.0.0",
   "description": "BackstopJS: Catch CSS curveballs.",
   "bin": {
     "backstop": "./cli/index.js"

--- a/test/backstop.json
+++ b/test/backstop.json
@@ -43,5 +43,5 @@
     "compare_data": "../../backstop_data/bitmaps_test/compare.json"
   },
   "engine": "phantomjs",
-  "report": ["CLI"]
+  "report": ["browser"]
 }


### PR DESCRIPTION
- Now loading the config file after we determine if we are running in "Legacy" mode.

- Aliased --config argument for setting configPath

- Report options now are `"CI"` &/or `browser`.  Default is `[ 'CI', 'browser']`

- report paths now default to /backstop_data/

- fixed cut and paste error `makeConfig.js` line 89.  (At least I think it was an error...)

